### PR TITLE
Initialize the about variable

### DIFF
--- a/template/src/About.vue
+++ b/template/src/About.vue
@@ -13,7 +13,7 @@ import { Watch, Prop } from 'vue-property-decorator';
 @Component({})
 export default class AboutComponent extends Vue {
   @Prop({type: String, default: 'watch out, this is required', required: true})
-  public about: string;
+  public about: string = "";
 
   @Watch('about')
   log(data: string) {


### PR DESCRIPTION
Fixes `TS2564: Property 'about' has no initializer and is not definitely assigned in the constructor.`